### PR TITLE
Add tests for edit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -63,9 +63,11 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_EDIT_LINEUP_SUCCESS = "Edited Lineup: %1$s";
+    public static final String MESSAGE_EDIT_SCHEDULE_SUCCESS = "Edited Schedule: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in MyGM.";
     public static final String MESSAGE_DUPLICATE_LINEUP = "This lineup already exists in MyGM.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in MyGM.";
+    public static final String MESSAGE_DUPLICATE_SCHEDULE = "This schedule already exists in MyGM.";
 
     private enum EditCommandType {
         PLAYER, LINEUP, SCHEDULE
@@ -185,12 +187,12 @@ public class EditCommand extends Command {
 
             // ok to have same schedule name, but not ok to have the description and date to be the same
             if (model.hasSchedule(editedSchedule)) {
-                throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+                throw new CommandException(MESSAGE_DUPLICATE_SCHEDULE);
             }
 
             model.setSchedule(scheduleToEdit, editedSchedule);
             model.updateFilteredScheduleList(Model.PREDICATE_SHOW_ALL_SCHEDULES);
-            return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedSchedule));
+            return new CommandResult(String.format(MESSAGE_EDIT_SCHEDULE_SUCCESS, editedSchedule));
         }
     }
 
@@ -257,10 +259,25 @@ public class EditCommand extends Command {
         if (!(other instanceof EditCommand)) {
             return false;
         }
+        // type check
+        EditCommand e = (EditCommand) other;
+        if (this.type != e.type) {
+            return false;
+        }
 
         // state check
-        EditCommand e = (EditCommand) other;
-        return editPersonDescriptor.equals(e.editPersonDescriptor);
+
+        if (this.type == EditCommandType.PLAYER) {
+            return this.editPersonDescriptor.equals(e.editPersonDescriptor) &&
+                    this.targetPlayerName.equals(e.targetPlayerName);
+        }
+        if (this.type == EditCommandType.LINEUP) {
+            return this.editLineupName.equals(e.editLineupName) &&
+                    this.targetLineupName.equals(e.targetLineupName);
+        }
+
+        return this.editScheduleDescriptor.equals(e.editScheduleDescriptor) &&
+                this.index.equals(e.index);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,166 +1,169 @@
 package seedu.address.logic.commands;
-/*
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_PF;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.lineup.Lineup;
+import seedu.address.model.lineup.LineupName;
 import seedu.address.model.person.Person;
+import seedu.address.model.schedule.Schedule;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.LineupBuilder;
 import seedu.address.testutil.PersonBuilder;
-*/
-/*
+
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
  */
 public class EditCommandTest {
 
-    /*
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model;
+    private static final LineupName EXISTING_LINEUP_NAME = new LineupBuilder().build().getLineupName();
+    private static final LineupName VALID_LINEUP_NAME = new LineupName("Lakaka");
+    private static final LineupName DUPLICATE_LINEUP_NAME = EXISTING_LINEUP_NAME;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model.addLineup(new LineupBuilder().build());
+    }
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_success() throws CommandException {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(BENSON.getName(), descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
-
-        assertTrue(true);
-        //assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        String res = editCommand.execute(model).getFeedbackToUser();
+        assertEquals(res, expectedMessage);
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
-        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
-
-        PersonBuilder personInList = new PersonBuilder(lastPerson);
+    public void execute_someFieldsSpecifiedUnfilteredList_success() throws CommandException {
+        PersonBuilder personInList = new PersonBuilder(BENSON);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_PF).build();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_PF).build();
+        EditCommand editCommand = new EditCommand(BENSON.getName(), descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(lastPerson, editedPerson);
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        String res = editCommand.execute(model).getFeedbackToUser();
+        assertEquals(res, expectedMessage);
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+    public void execute_noFieldSpecifiedUnfilteredList_success() throws CommandException {
+        EditCommand editCommand = new EditCommand(BENSON.getName(), new EditPersonDescriptor());
+        Person editedPerson = new PersonBuilder(BENSON).build();
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        String res = editCommand.execute(model).getFeedbackToUser();
+        assertEquals(res, expectedMessage);
     }
 
     @Test
-    public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+    public void execute_filteredList_success() throws CommandException {
+        Person editedPerson = new PersonBuilder(BENSON).withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(BENSON.getName(),
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
-
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        String res = editCommand.execute(model).getFeedbackToUser();
+        assertEquals(res, expectedMessage);
     }
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Person secondPerson = model.getFilteredPersonList().get(0); //Alice
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(secondPerson).build();
+        EditCommand editCommand = new EditCommand(BENSON.getName(), descriptor);
+        try {
+            editCommand.execute(model);
 
-        // edit person in filtered list into a duplicate in address book
-        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPersonDescriptorBuilder(personInList).build());
-
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        } catch (CommandException e) {
+            assertEquals(e.getMessage(), EditCommand.MESSAGE_DUPLICATE_PERSON);
+        }
     }
 
     @Test
-    public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
-
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-    }
-
-    */
-
-
-
-    /*
-    /**
-     * Edit filtered list where index is larger than size of filtered list,
-     * but smaller than size of address book
-     */
-    /*
-    @Test
-    public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
-
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
-
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    public void execute_duplicatePersonUnfilteredList_failure() {
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(CARL).build();
+        EditCommand editCommand = new EditCommand(BENSON.getName(),
+                descriptor);
+        try {
+            editCommand.execute(model);
+        } catch (CommandException e) {
+            assertEquals(e.getMessage(), EditCommand.MESSAGE_DUPLICATE_PERSON);
+        }
     }
 
     @Test
-    public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+    public void execute_editLineupName_success() throws CommandException {
+        EditCommand standardCommand = new EditCommand(EXISTING_LINEUP_NAME, VALID_LINEUP_NAME);
+        String msg = standardCommand.execute(model).getFeedbackToUser();
+        Lineup editedLineup = model.getLineup(VALID_LINEUP_NAME);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_LINEUP_SUCCESS, editedLineup);
+        assertEquals(msg, expectedMessage);
+    }
 
-        // same values -> returns true
+    @Test
+    public void execute_duplicateLineupName_failure() {
+        model.addLineup(new Lineup(VALID_LINEUP_NAME));
+        EditCommand standardCommand = new EditCommand(EXISTING_LINEUP_NAME, VALID_LINEUP_NAME);
+        try {
+            standardCommand.execute(model);
+        } catch (CommandException e) {
+            assertEquals(e.getMessage(), EditCommand.MESSAGE_DUPLICATE_LINEUP);
+        }
+    }
+
+    @Test
+    public void execute_editSchedule_success() {
+        // EditCommand standardCommand = new EditCommand()
+        assert(true);
+    }
+
+    @Test
+    public void execute_invalidScheduleIndex_failure() {
+        assert(true);
+    }
+
+    @Test
+    public void execute_duplicateSchedule_failure() {
+        assert(true);
+    }
+
+    @Test
+    public void equalsEditPerson() {
+        final EditCommand standardCommand = new EditCommand(BENSON.getName(), DESC_AMY);
+
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(BENSON.getName(), copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -172,11 +175,31 @@ public class EditCommandTest {
         // different types -> returns false
         assertFalse(standardCommand.equals(new ClearCommand()));
 
-        // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
-
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(BENSON.getName(), DESC_BOB)));
     }
-    */
+
+    @Test
+    public void equalsEditLineup() {
+
+        final EditCommand editLineupCommand = new EditCommand(EXISTING_LINEUP_NAME, VALID_LINEUP_NAME);
+        final EditCommand sameEditLinupCommand = new EditCommand(EXISTING_LINEUP_NAME, VALID_LINEUP_NAME);
+
+        // same object -> returns true
+        assertTrue(editLineupCommand.equals(sameEditLinupCommand));
+
+        //null -> returns false
+        assertFalse(editLineupCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(editLineupCommand.equals(new ClearCommand()));
+
+        // different lineupName -> returns false
+        assertFalse(editLineupCommand.equals(new EditCommand(EXISTING_LINEUP_NAME, DUPLICATE_LINEUP_NAME)));
+    }
+
+    @Test
+    public void equalsEditSchedule() {
+
+    }
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -5,10 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -35,6 +32,9 @@ public class EditPersonDescriptorBuilder {
         descriptor.setPhone(person.getPhone());
         descriptor.setEmail(person.getEmail());
         descriptor.setTags(person.getTags());
+        descriptor.setHeight(person.getHeight());
+        descriptor.setWeight(person.getWeight());
+        descriptor.setJerseyNumber(person.getJerseyNumber());
     }
 
     /**
@@ -42,6 +42,30 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withName(String name) {
         descriptor.setName(new Name(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Height} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withHeight(String height) {
+        descriptor.setHeight(new Height(height));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Weight} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withWeight(String weight) {
+        descriptor.setWeight(new Weight(weight));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Weight} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withJerseyNumber(String jerseyNumber) {
+        descriptor.setJerseyNumber(new JerseyNumber(jerseyNumber));
         return this;
     }
 


### PR DESCRIPTION
Add tests for edit command covering 
1. edit lineup
2. edit person
3. equals()

Fixed equals() for EditCommand class to allow comparison between edit commands for person, lineup and schedule.

To be modified:
- [ ] Tests for edit schedule
- [ ] Tests for delete schedule