### PR TITLE
Update display order for player and schedule

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -20,12 +20,17 @@ import seedu.address.model.lineup.Lineup;
 import seedu.address.model.person.Person;
 import seedu.address.model.schedule.Schedule;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 /**
  * Adds a person to the address book.
  */
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
 
     public static final String MESSAGE_USAGE_PLAYER = COMMAND_WORD + ": Adds a player to MyGM. "
             + "\nParameters: "
@@ -47,7 +52,7 @@ public class AddCommand extends Command {
             + PREFIX_WEIGHT + "80 "
             + PREFIX_TAG + "PG "
             + PREFIX_TAG + "SG";
-    public static final String MESSAGE_USAGE_LINEUP = COMMAND_WORD + ":Adds a lineup to MyGM."
+    public static final String MESSAGE_USAGE_LINEUP = COMMAND_WORD + ": Adds a lineup to MyGM."
             + "\nParameters: "
             + PREFIX_LINEUP + " "
             + PREFIX_NAME + "LINEUP NAME"
@@ -55,16 +60,16 @@ public class AddCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_LINEUP + " "
             + PREFIX_NAME + "Starting 5";
-    public static final String MESSAGE_USAGE_SCHEDULE = COMMAND_WORD + ":Adds a schedule to MyGM."
+    public static final String MESSAGE_USAGE_SCHEDULE = COMMAND_WORD + ": Adds a schedule to MyGM."
             + "\nParameters: "
             + PREFIX_SCHEDULE + " "
-            + PREFIX_NAME + "SCHEDULE NAME"
-            + PREFIX_DESCRIPTION + "SCHEDULE NAME "
+            + PREFIX_NAME + "SCHEDULE NAME "
+            + PREFIX_DESCRIPTION + "SCHEDULE DESCRIPTION "
             + PREFIX_DATE + "DATE TIME\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_SCHEDULE + " "
-            + PREFIX_NAME + "finals"
-            + PREFIX_DESCRIPTION + "nba finals"
+            + PREFIX_NAME + "finals "
+            + PREFIX_DESCRIPTION + "nba finals "
             + PREFIX_DATE + "01/01/2022 2000";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a player, lineup, schedule to MyGM\n"
@@ -82,6 +87,7 @@ public class AddCommand extends Command {
             + "You may consider these available ones:\n%1$s";
     public static final String MESSAGE_FULL_CAPACITY_REACHED = "MyGM has reached its full capacity with 100 players.";
     // can consider adding in a list of available jersey number
+    public static final String MESSAGE_OUTDATED_DATE = "Date should be after %s.";
 
     private final Person toAddPerson;
     private final Lineup toAddLineup;
@@ -154,6 +160,11 @@ public class AddCommand extends Command {
             model.addLineup(toAddLineup);
             return new CommandResult(String.format(MESSAGE_ADD_LINEUP_SUCCESS, toAddLineup));
         } else {
+            LocalDateTime ldt = LocalDateTime.now();
+            if (toAddSchedule.getScheduleDateTime().getScheduleDateTime().isBefore(ldt)) {
+                throw new CommandException(String.format(MESSAGE_OUTDATED_DATE, ldt.format(FORMATTER)));
+            }
+
             if (model.hasSchedule(toAddSchedule)) {
                 throw new CommandException(MESSAGE_DUPLICATE_PERSON);
             }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -270,6 +270,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     public void refresh() {
         persons.refresh();
+        schedules.refresh();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/PersonComparator.java
+++ b/src/main/java/seedu/address/model/person/PersonComparator.java
@@ -1,0 +1,16 @@
+package seedu.address.model.person;
+
+import java.util.Comparator;
+
+
+/**
+ * A comparator to compare between objects of {@code Person}.
+ *
+ * @see Person#isSamePerson(Person)
+ */
+public class PersonComparator implements Comparator<Person> {
+    @Override
+    public int compare(Person p1, Person p2) {
+        return p1.getName().toString().compareTo(p2.getName().toString());
+    }
+}

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -33,6 +33,7 @@ public class UniquePersonList implements Iterable<Person> {
     private final ObservableList<Person> internalList = FXCollections.observableArrayList();
     private final ObservableList<Person> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
+    private final PersonComparator comparator = new PersonComparator();
 
     /**
      * Returns true if the list contains an equivalent person as the given argument.
@@ -43,9 +44,17 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Return true if some person with {@code targetName}
-     * @param targetName
-     * @return
+     * Sort the internal list for display.
+     * Called when there is a change in person inside the list except for deleting.
+     */
+    private void sort() {
+        this.internalList.sort(comparator);
+    }
+
+    /**
+     * Return true if some person with {@code targetName}.
+     * @param targetName to check existence.
+     * @return true if the name exists.
      */
     public boolean containsName(Name targetName) {
         requireNonNull(targetName);
@@ -70,6 +79,7 @@ public class UniquePersonList implements Iterable<Person> {
     public void refresh() {
         List<Person> playersCopy = new ArrayList<>(internalList);
         internalList.setAll(playersCopy);
+        sort();
     }
 
     /**
@@ -164,12 +174,12 @@ public class UniquePersonList implements Iterable<Person> {
 
     /**
      * Returns a string representation of a list of available Jersey Number.
-     * @return
+     * @return a string of available Jersey Number.
      */
     public String getAvailableJerseyNumber() {
         Stream<Integer> stream = IntStream.range(0, MAXIMUM_CAPACITY).boxed();
         List<Integer> ls = stream
-                .filter(x -> !this.containsJerseyNumber(new JerseyNumber(((Integer) x).toString())))
+                .filter(x -> !this.containsJerseyNumber(new JerseyNumber((x).toString())))
                 .collect(Collectors.toList());
         return ls.toString();
     }

--- a/src/main/java/seedu/address/model/schedule/ScheduleComparator.java
+++ b/src/main/java/seedu/address/model/schedule/ScheduleComparator.java
@@ -1,0 +1,20 @@
+package seedu.address.model.schedule;
+
+import java.util.Comparator;
+import java.time.LocalDateTime;
+
+/**
+ * A comparator to compare between objects of {@code Person}.
+ *
+ */
+public class ScheduleComparator implements Comparator<Schedule> {
+    @Override
+    public int compare(Schedule s1, Schedule s2) {
+        LocalDateTime d1 = s1.getScheduleDateTime().getScheduleDateTime();
+        LocalDateTime d2 = s2.getScheduleDateTime().getScheduleDateTime();
+        if (d2.isBefore(d1)) {
+            return 1;
+        }
+        return -1;
+    }
+}

--- a/src/main/java/seedu/address/model/schedule/UniqueScheduleList.java
+++ b/src/main/java/seedu/address/model/schedule/UniqueScheduleList.java
@@ -3,11 +3,13 @@ package seedu.address.model.schedule;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.person.Person;
 import seedu.address.model.schedule.exceptions.DuplicateScheduleException;
 import seedu.address.model.schedule.exceptions.ScheduleNotFoundException;
 
@@ -18,6 +20,7 @@ public class UniqueScheduleList implements Iterable<Schedule> {
     private final ObservableList<Schedule> internalList = FXCollections.observableArrayList();
     private final ObservableList<Schedule> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
+    private final ScheduleComparator comparator = new ScheduleComparator();
 
     /**
      * Returns true if the list contains an equivalent schedule as the given argument.
@@ -25,6 +28,23 @@ public class UniqueScheduleList implements Iterable<Schedule> {
     public boolean contains(Schedule toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::equals);
+    }
+
+    /**
+     * Sort the internal list for display.
+     * Called when there is a change in {@code Schedule} inside the list except for deleting.
+     */
+    private void sort() {
+        this.internalList.sort(comparator);
+    }
+
+    /**
+     * Refreshes the observable list so that update can be reflected in GUI.
+     */
+    public void refresh() {
+        List<Schedule> schedulesCopy = new ArrayList<>(internalList);
+        internalList.setAll(schedulesCopy);
+        sort();
     }
 
     /**


### PR DESCRIPTION
Updates:
1. Display players in ascending order of name character
2. Display schedules in ascending order of future dates
3. Impose restriction on schedule to be future dates of now

Fixed:
1. String format for `add schedule` command instruction