### PR TITLE
Update view commands for Schedule

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -276,6 +276,7 @@ The predicates are then combined and used to filter the `FilteredList<Person>`. 
 The following sequence diagram shows how the find operation works:
 Sequence Diagram:
 __TO BE ADDED__
+
 #### Design Consideration
 For future development (v1.3b), may consider to enter more flags so that user can perform more specific view task.
 
@@ -285,7 +286,36 @@ For future development (v1.3b), may consider to enter more flags so that user ca
 
 #### 4.3 View schedule
 #### Proposed implementation
+The proposed implementation of view schedule has three variants, which differ in Step 2 and 3 of user scenarios.
+
+Step 1. The user launches the application.
+
+Step 2a. The user wants to view active schedules happening at future dates.
+
+Step 3a. The user executes `view S/`.  The command will set the predicate for `FilteredList<Schedule>` to be `PREDICATE_SHOW_ACTIVE_SCHEDULES`.
+
+Step 2b. The user wants to view all schedules added.
+
+Step 3b. The user executes `view S/ a/all`.  The command will set the predicate for `FilteredList<Schedule>` to be `PREDICATE_SHOW_ALL_SCHEDULES`.
+
+Step 2b. The user wants to view archived schedules only.
+
+Step 3b. The user executes `view S/ a/archive`.  The command will set the predicate for `FilteredList<Schedule>` to be `PREDICATE_SHOW_ARCHIVED_SCHEDULES`.
+
+The following sequence diagram shows how the find operation works:
+Sequence Diagram:
+__TO BE ADDED__
+
 #### Design Consideration
+**Aspect: How to set the default display of schedule to active schedules only:**
+
+* **Alternative 1 (current choice):** Set the predicate at initialization of `AddressBook`.
+    * Pros: Easy to implement.
+    * Cons: Risk breaking abstraction principle because `LogicManager` is implementing for `ModelManager`.
+
+* **Alternative 2:** Set the predicate inside `ModelManager`.
+  * Pros: `LogicManager` will not call functions other than `get...()` of `ModelManager`.
+  * Cons: Difficult to implement.
 
 ### 5. Put feature
 Puts a `Person` into a `Lineup`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -187,11 +187,19 @@ Examples:
 * `view P/Kelvin Darent` Displays the information of `Kelvin Darent`.
 * `view P/` Displays all players in the system.
 
-**To view a schedule:**<br>
+**To view schedules:**<br>
 
-Format: `view i/[INDEX]`
-* Displays the schedule of the specified `` numbered with the specified `INDEX`.
-* If no `INDEX` is provided, the list of all schedules of the `` will be displayed.
+Format: `view S/[KEYWORDS]`
+* Displays the schedule containing `KEYWORDS`, cases ignored.
+* If no `KEYWORDS` is provided, the list of all active schedules which happen at future dates will be displayed.
+
+Format: `view S/ a/all`
+* Displays all schedules added.
+* If no `all` is provided, error message will be displayed.
+
+Format: `view S/ a/archive`
+* Displays archived schedules only.
+* If no `archive` is provided, error message will be displayed.
 
 Examples:
 * `view i/1` Displays the information on `Lakaka`'s 1st schedule.

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -12,5 +12,6 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX = "The schedule index provided is invalid";
     public static final String MESSAGE_SCHEDULE_LISTED_OVERVIEW = "%1$d schedules listed!";
+    public static final String MESSAGE_INVALID_ACTIVE_SCHEDULE_FORMAT = "Invalid view schedule command format! \n%1$s";
 
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -69,6 +69,7 @@ public class LogicManager implements Logic {
 
     @Override
     public ObservableList<Schedule> getFilteredScheduleList() {
+        model.updateFilteredScheduleList(Model.PREDICATE_SHOW_ACTIVE_SCHEDULES);
         return model.getFilteredScheduleList();
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -64,7 +64,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_PERSON_NOT_IN_LINEUP = "Player is not inside the lineup";
     public static final String MESSAGE_DELETE_PERSON_FROM_LINEUP_SUCCESS = "Person deleted from lineup %s: %s";
     public static final String MESSAGE_DELETE_LINEUP_SUCCESS = "Deleted Lineup: %s";
-    public static final String MESSAGE_DELETE_SCHEDULE_SUCCESS = "Deleted Schedule: %1%s";
+    public static final String MESSAGE_DELETE_SCHEDULE_SUCCESS = "Deleted Schedule: %s";
     public static final String MESSAGE_DELETE_FAILURE = "Delete cannot be executed.";
 
     private enum DeleteCommandType {

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LINEUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLAYER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ALL_SCHEDULE;
+
 
 import java.util.List;
 import java.util.function.Predicate;

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -1,9 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LINEUP;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PLAYER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -36,12 +34,17 @@ public class ViewCommand extends Command {
             + "Parameters: " + PREFIX_SCHEDULE + "[SCHEDULE NAME]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_SCHEDULE + "finals";
 
+    public static final String MESSAGE_ACTIVE_SCHEDULE_USAGE = COMMAND_WORD
+            + ": To view all schedules\n"
+            + "Parameters: " + PREFIX_SCHEDULE + " " + PREFIX_ALL_SCHEDULE + "all\n"
+            + "To view archived schedules\n"
+            + "Parameters: " + PREFIX_SCHEDULE + " " + PREFIX_ALL_SCHEDULE + "archive\n";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Views information of players, lineups and schedules.\n"
             + MESSAGE_USAGE_PLAYER + "\n"
             + MESSAGE_USAGE_LINEUP + "\n"
             + MESSAGE_USAGE_SCHEDULE;
 
-    private static String successMessage = "Listed all information!";
+    private static String MESSAGE_VIEW_SUCCESS = "Listed all information!";
 
     private final Predicate<Person> predicate;
     private final Predicate<Schedule> predicateSchedule;
@@ -76,18 +79,18 @@ public class ViewCommand extends Command {
             model.updateFilteredScheduleList(predicateSchedule);
         }
         changeSuccessMessage(model);
-        return new CommandResult(successMessage);
+        return new CommandResult(MESSAGE_VIEW_SUCCESS);
     }
 
     private void changeSuccessMessage(Model model) {
         if (keywords.size() > 1 && (keywords.contains("L/") || keywords.contains("P/"))) {
-            successMessage = String.format(
+            MESSAGE_VIEW_SUCCESS = String.format(
                     Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size());
         } else if (keywords.contains("S/")) {
-            successMessage = String.format(
+            MESSAGE_VIEW_SUCCESS = String.format(
                     Messages.MESSAGE_SCHEDULE_LISTED_OVERVIEW, model.getFilteredScheduleList().size());
         } else {
-            successMessage = "Listed all persons!";
+            MESSAGE_VIEW_SUCCESS = "Listed all persons!";
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -1,7 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LINEUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLAYER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ALL_SCHEDULE;
 
 import java.util.List;
 import java.util.function.Predicate;

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -16,6 +16,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PLAYER = new Prefix("P/");
     public static final Prefix PREFIX_INDEX = new Prefix("i/");
     public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_ALL_SCHEDULE = new Prefix("a/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("r/");
     public static final Prefix PREFIX_SCHEDULE = new Prefix("S/");
     public static final Prefix PREFIX_LINEUP = new Prefix("L/");

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -2,8 +2,16 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ACTIVE_SCHEDULE_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
-import static seedu.address.model.Model.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LINEUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLAYER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ALL_SCHEDULE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS_WITH_LINEUP;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SCHEDULES;
+import static seedu.address.model.Model.PREDICATE_SHOW_ACTIVE_SCHEDULES;
+import static seedu.address.model.Model.PREDICATE_SHOW_ARCHIVED_SCHEDULES;
+
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,12 +1,9 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ACTIVE_SCHEDULE_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LINEUP;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PLAYER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS_WITH_LINEUP;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SCHEDULES;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.model.Model.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,10 +16,15 @@ import seedu.address.model.person.LineupNameContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.schedule.ScheduleNameContainsKeywordsPredicate;
 
+import javax.swing.text.View;
+
 /**
  * Parses input arguments and creates a new ViewCommand object
  */
 public class ViewCommandParser implements Parser<ViewCommand> {
+
+    private static final String ALL_SCHEDULES = "all";
+    private static final String ARCHIVED_SCHEDULES = "archive";
 
     /**
      * Parses the given {@code String} of arguments in the context of the ViewCommand
@@ -31,7 +33,8 @@ public class ViewCommandParser implements Parser<ViewCommand> {
      */
     @Override
     public ViewCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PLAYER, PREFIX_LINEUP, PREFIX_SCHEDULE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PLAYER, PREFIX_LINEUP, PREFIX_SCHEDULE
+                , PREFIX_ALL_SCHEDULE);
 
         boolean hasPSlash = arePrefixesPresent(argMultimap, PREFIX_PLAYER); // P/
         boolean hasLSlash = arePrefixesPresent(argMultimap, PREFIX_LINEUP); // L/
@@ -108,9 +111,26 @@ public class ViewCommandParser implements Parser<ViewCommand> {
             List<String> prefixAndArgument = new ArrayList<>();
             prefixAndArgument.add(PREFIX_SCHEDULE.toString());
 
-            // view P/ --> view all player
+            // view S/ -> view all active schedules by default
             if (args.equals(" S/")) {
-                return new ViewCommand(null, PREDICATE_SHOW_ALL_SCHEDULES, prefixAndArgument);
+                return new ViewCommand(null, PREDICATE_SHOW_ACTIVE_SCHEDULES, prefixAndArgument);
+            }
+
+            System.out.println(arePrefixesPresent(argMultimap, PREFIX_ALL_SCHEDULE));
+            // view all schedules
+            if (arePrefixesPresent(argMultimap, PREFIX_ALL_SCHEDULE)) {
+                System.out.println(argMultimap.getValue(PREFIX_ALL_SCHEDULE));
+                if (argMultimap.getValue(PREFIX_ALL_SCHEDULE).get().equals(ARCHIVED_SCHEDULES)) {
+                    System.out.println("archived");
+                    return new ViewCommand(null, PREDICATE_SHOW_ARCHIVED_SCHEDULES, prefixAndArgument);
+                }
+                if (argMultimap.getValue(PREFIX_ALL_SCHEDULE).get().equals(ALL_SCHEDULES)) {
+                    System.out.println("all");
+                    return new ViewCommand(null, PREDICATE_SHOW_ALL_SCHEDULES, prefixAndArgument);
+                } else {
+                    throw new ParseException(String.format(MESSAGE_INVALID_ACTIVE_SCHEDULE_FORMAT,
+                            ViewCommand.MESSAGE_ACTIVE_SCHEDULE_USAGE));
+                }
             }
 
             // check has preamble. check here because if arg = "S/", preamble = "S/" as well

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -21,7 +21,8 @@ public interface Model {
 
     /** {@code Predicate} that evaluates to true when a person has lineup name*/
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS_WITH_LINEUP = person -> !person.getLineupNames().isEmpty();
-
+    Predicate<Schedule> PREDICATE_SHOW_ACTIVE_SCHEDULES = schedule -> schedule.isActive();
+    Predicate<Schedule> PREDICATE_SHOW_ARCHIVED_SCHEDULES = schedule -> !schedule.isActive();
     //=========== MyGM (Start) =====================================================================
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/address/model/schedule/Schedule.java
+++ b/src/main/java/seedu/address/model/schedule/Schedule.java
@@ -3,6 +3,7 @@ package seedu.address.model.schedule;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 /**
@@ -42,6 +43,14 @@ public class Schedule {
     public boolean isMatchName(ScheduleName targetName) {
         requireNonNull(targetName);
         return getScheduleName().equals(targetName);
+    }
+
+    /**
+     * Returns true if the event is still active, i.e. on a future date.
+     */
+    public boolean isActive() {
+        LocalDateTime now = LocalDateTime.now();
+        return scheduleDateTime.getScheduleDateTime().isAfter(now);
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -87,7 +87,10 @@ public class SampleDataUtil {
                 new ScheduleDateTime("19/02/2020 1200")),
             new Schedule(new ScheduleName("Free throw practice"),
                 new ScheduleDescription("Dwight needs to improve free throws"),
-                new ScheduleDateTime("19/06/2021 1200"))
+                new ScheduleDateTime("19/06/2021 1200")),
+            new Schedule(new ScheduleName("An active schedule"),
+                    new ScheduleDescription("Dwight needs to improve free throws"),
+                    new ScheduleDateTime("19/06/2023 1200"))
         };
     }
 


### PR DESCRIPTION
 updated schedule to display only active ones by default

`view S/`
will display active schedules

`view S/ a/all`
will display all schedules ever added

`view S/ a/archive`
will display only archived (expired) schedules
