### PR TITLE
Fix edit schedule

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -15,6 +15,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 //import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -225,7 +226,11 @@ public class EditCommand extends Command {
             }
 
             model.setSchedule(scheduleToEdit, editedSchedule);
-            model.updateFilteredScheduleList(Model.PREDICATE_SHOW_ACTIVE_SCHEDULES);
+            if (editedSchedule.isActive()) {
+                model.updateFilteredScheduleList(Model.PREDICATE_SHOW_ACTIVE_SCHEDULES);
+            } else {
+                model.updateFilteredScheduleList(Model.PREDICATE_SHOW_ALL_SCHEDULES);
+            }
             return new CommandResult(String.format(MESSAGE_EDIT_SCHEDULE_SUCCESS, editedSchedule));
         }
     }


### PR DESCRIPTION
Now edit behaviour is
1. If the edited schedule is active: show all active schedules
2. Else: show all schedules

Would this be better than only show active schedules after editing?